### PR TITLE
Remove non-numerics from memory_limit config value

### DIFF
--- a/pclzip.lib.php
+++ b/pclzip.lib.php
@@ -1787,6 +1787,7 @@ class PclZip
         $v_memory_limit = ini_get('memory_limit');
         $v_memory_limit = trim($v_memory_limit);
         $last           = strtolower(substr($v_memory_limit, -1));
+        $v_memory_limit = preg_replace('/[^0-9,.]/', '', $v_memory_limit);
 
         if ($last == 'g') {
             //$v_memory_limit = $v_memory_limit*1024*1024*1024;


### PR DESCRIPTION
Fix for `A non well formed numeric value encountered` warning.