### PR TITLE
Avoid: a non well formed numeric value encountered

### DIFF
--- a/pclzip.lib.php
+++ b/pclzip.lib.php
@@ -1787,6 +1787,7 @@ class PclZip
         $v_memory_limit = ini_get('memory_limit');
         $v_memory_limit = trim($v_memory_limit);
         $last           = strtolower(substr($v_memory_limit, -1));
+        $v_memory_limit = intval($v_memory_limit);
 
         if ($last == 'g') {
             //$v_memory_limit = $v_memory_limit*1024*1024*1024;


### PR DESCRIPTION
`'128M' * 1048576` will cause notice in PHP 7.1

`128' * 1048576` will not cause notice in PHP 7.1